### PR TITLE
bugfixed for number validations in validations

### DIFF
--- a/ui-app/client/src/util/validationProcessor.ts
+++ b/ui-app/client/src/util/validationProcessor.ts
@@ -80,7 +80,7 @@ function NUMBER_VALUE(validation: any, value: any): Array<string> {
 	if (isNaN(floatValue) || '' + floatValue !== '' + value) return [validation.message];
 	if (!isNullValue(validation.minValue) && floatValue < parseFloat(validation.minValue))
 		return [validation.message];
-	if (!isNullValue(validation.maxValue) && floatValue > parseInt(validation.maxValue))
+	if (!isNullValue(validation.maxValue) && floatValue > parseFloat(validation.maxValue))
 		return [validation.message];
 	return [];
 }

--- a/ui-app/client/src/util/validationProcessor.ts
+++ b/ui-app/client/src/util/validationProcessor.ts
@@ -70,19 +70,21 @@ function EMAIL(validation: any, value: any): Array<string> {
 	return [];
 }
 
+//function DATE_FORMAT(validation: any, value: any): Array<string> {
+//	return [];
+//}
+
 function NUMBER_VALUE(validation: any, value: any): Array<string> {
 	if (isNullValue(value)) return [];
-	const intValue = parseInt(value);
-	if (isNaN(intValue) || '' + intValue !== '' + value) return [validation.message];
-	if (!isNullValue(validation.minValue) && intValue < parseInt(validation.minValue))
+	const floatValue = parseFloat(value);
+	if (isNaN(floatValue) || '' + floatValue !== '' + value) return [validation.message];
+	if (!isNullValue(validation.minValue) && floatValue < parseFloat(validation.minValue))
 		return [validation.message];
-	if (!isNullValue(validation.maxValue) && intValue > parseInt(validation.maxValue))
+	if (!isNullValue(validation.maxValue) && floatValue > parseInt(validation.maxValue))
 		return [validation.message];
 	return [];
 }
-// function DATE_FORMAT(validation: any, value: any): Array<string> {
-// 	return [];
-// }
+ 
 
 function FILE_SIZE(validation: any, value: FileList): Array<string> {
 	if (isNullValue(value)) return [];
@@ -168,6 +170,7 @@ export const VALIDATION_FUNCTIONS: {
 		],
 	},
 	EMAIL: { functionCode: EMAIL, displayName: 'Email' },
+	//DATE_FORMAT : {functionCode: DATE_FORMAT, displayName:'Date'},
 	NUMBER_VALUE: {
 		functionCode: NUMBER_VALUE,
 		displayName: 'Number',


### PR DESCRIPTION
when we selected the validation type number and kept minimum value, the error message is triggering even the value is given greater than 0 or the decimal values  so fixed it by replacing the pareseInt() by parseFloat() function