### PR TITLE
Validate iframe src and show error message if invalid

### DIFF
--- a/ui-app/client/src/components/Iframe/Iframe.tsx
+++ b/ui-app/client/src/components/Iframe/Iframe.tsx
@@ -39,6 +39,32 @@ function Iframe(props: ComponentProps) {
 		{},
 		stylePropertiesWithPseudoStates,
 	);
+
+	if (!src || src.trim() === '') {
+		return null; // Returning null if src is not provided or empty
+	}
+
+	// if want to validate the url as well
+	const isValidURL = (url: any) => {
+		if (!url || url.trim() === '') {
+			return true; // Treating empty or null URLs as valid for this purpose
+		}
+		try {
+			new URL(url);
+			return true;
+		} catch {
+			return false;
+		}
+	};
+
+	if (!isValidURL(src)) {
+		return (
+			<div className="invalid-url">
+				The URL provided is incorrect, please insert the correct embedded URL.
+			</div>
+		);
+	}
+
 	return (
 		<div className="comp compIframe" style={resolvedStyles.comp ?? {}}>
 			<HelperComponent context={props.context} definition={definition} />

--- a/ui-app/client/src/components/Iframe/Iframe.tsx
+++ b/ui-app/client/src/components/Iframe/Iframe.tsx
@@ -40,21 +40,20 @@ function Iframe(props: ComponentProps) {
 		stylePropertiesWithPseudoStates,
 	);
 
-	const shouldRenderIframe = (srcdoc: any, src: any) => {
-		if (srcdoc) return true;
-		if (!src || !src.trim()) return false;
+	let shouldRenderIframe = true;
+
+	if (!srcdoc?.trim()) {
 		try {
 			new URL(src);
-			return true;
-		} catch (e) {
-			return false;
+		} catch (err) {
+			shouldRenderIframe = false;
 		}
-	};
+	}
 
 	return (
 		<div className="comp compIframe" style={resolvedStyles.comp ?? {}}>
 			<HelperComponent context={props.context} definition={definition} />
-			{shouldRenderIframe(srcdoc, src) ? (
+			{shouldRenderIframe ? (
 				<iframe
 					className="iframe"
 					style={resolvedStyles.iframe ?? {}}

--- a/ui-app/client/src/components/Iframe/Iframe.tsx
+++ b/ui-app/client/src/components/Iframe/Iframe.tsx
@@ -40,51 +40,40 @@ function Iframe(props: ComponentProps) {
 		stylePropertiesWithPseudoStates,
 	);
 
-	if (!src || src.trim() === '') {
-		return null; // Returning null if src is not provided or empty
-	}
-
-	// if want to validate the url as well
-	const isValidURL = (url: any) => {
-		if (!url || url.trim() === '') {
-			return true; // Treating empty or null URLs as valid for this purpose
-		}
+	const shouldRenderIframe = (srcdoc: any, src: any) => {
+		if (srcdoc) return true;
+		if (!src || !src.trim()) return false;
 		try {
-			new URL(url);
+			new URL(src);
 			return true;
-		} catch {
+		} catch (e) {
 			return false;
 		}
 	};
 
-	if (!isValidURL(src)) {
-		return (
-			<div className="invalid-url">
-				The URL provided is incorrect, please insert the correct embedded URL.
-			</div>
-		);
-	}
-
 	return (
 		<div className="comp compIframe" style={resolvedStyles.comp ?? {}}>
 			<HelperComponent context={props.context} definition={definition} />
-			<iframe
-				className="iframe"
-				style={resolvedStyles.iframe ?? {}}
-				width={width}
-				src={src}
-				height={height}
-				name={name}
-				loading={loading}
-				allow={allow}
-				sandbox={sandbox}
-				referrerPolicy={referrerpolicy}
-				allowFullScreen={allowfullscreen}
-				srcDoc={srcdoc}
-			></iframe>
+			{shouldRenderIframe(srcdoc, src) ? (
+				<iframe
+					className="iframe"
+					style={resolvedStyles.iframe ?? {}}
+					width={width}
+					src={srcdoc ? undefined : src}
+					srcDoc={srcdoc}
+					height={height}
+					name={name}
+					loading={loading}
+					allow={allow}
+					sandbox={sandbox}
+					referrerPolicy={referrerpolicy}
+					allowFullScreen={allowfullscreen}
+				></iframe>
+			) : null}
 		</div>
 	);
 }
+
 const component: Component = {
 	name: 'Iframe',
 	displayName: 'Iframe',


### PR DESCRIPTION
This change adds a validation check for the iframe src URL. If the URL is invalid, it displays a div with an error message. If the URL is empty or null, the iframe component does not occupy any space.