### PR TITLE
Fixed issues in parent path extraction.

### DIFF
--- a/ui-app/client/src/context/ParentExtractor.ts
+++ b/ui-app/client/src/context/ParentExtractor.ts
@@ -50,17 +50,17 @@ export class ParentExtractor extends SpecialTokenValueExtractor {
 		let currentHistory = this.history;
 
 		do {
-			let { path, lastHistory } = this.getPathInternal(token, currentHistory);
+			let { path, lastHistory, removeHistory } = this.getPathInternal(token, currentHistory);
 			if (!path.startsWith('Parent.')) return { path, lastHistory };
 			token = path;
-			currentHistory = currentHistory.slice(0, currentHistory.length - 1);
+			currentHistory = currentHistory.slice(0, currentHistory.length - removeHistory);
 		} while (true);
 	}
 
 	public getPathInternal(
 		token: string,
 		locationHistory: LocationHistory[],
-	): { path: string; lastHistory: LocationHistory } {
+	): { path: string; lastHistory: LocationHistory; removeHistory: number } {
 		const parts: string[] = token.split(TokenValueExtractor.REGEX_DOT);
 
 		let pNum: number = 0;
@@ -78,7 +78,7 @@ export class ParentExtractor extends SpecialTokenValueExtractor {
 					: lastHistory.location.expression
 			}.${parts.slice(pNum).join('.')}`;
 
-		return { path, lastHistory };
+		return { path, lastHistory, removeHistory: pNum };
 	}
 
 	public getStore(): any {
@@ -140,14 +140,17 @@ export class ParentExtractorForRunEvent extends TokenValueExtractor {
 		let currentHistory = this.history;
 
 		do {
-			let path = this.computeParentPathInternal(token, currentHistory);
+			let { path, removeHistory } = this.computeParentPathInternal(token, currentHistory);
 			if (!path.startsWith('Parent.')) return path;
 			token = path;
-			currentHistory = currentHistory.slice(0, currentHistory.length - 1);
+			currentHistory = currentHistory.slice(0, currentHistory.length - removeHistory);
 		} while (true);
 	}
 
-	public computeParentPathInternal(token: string, history: LocationHistory[]): string {
+	public computeParentPathInternal(
+		token: string,
+		history: LocationHistory[],
+	): { path: string; removeHistory: number } {
 		const parts: string[] = token.split(TokenValueExtractor.REGEX_DOT);
 
 		let pNum: number = 0;
@@ -158,6 +161,7 @@ export class ParentExtractorForRunEvent extends TokenValueExtractor {
 		let lastHistory;
 
 		lastHistory = history[history.length - pNum];
+
 		if (typeof lastHistory?.location === 'string') path = `${lastHistory.location}.${path}`;
 		else if (lastHistory?.location)
 			path = `${
@@ -166,7 +170,7 @@ export class ParentExtractorForRunEvent extends TokenValueExtractor {
 					: lastHistory.location.expression
 			}.${path}`;
 
-		return path;
+		return { path, removeHistory: pNum };
 	}
 
 	public getPath(token: string): { path: string; lastHistory: LocationHistory } {


### PR DESCRIPTION
When there is are 3 or levels of nesting of repeaters or tables and trying to access parent objects in the middle causing wrong represtation of path.