### PR TITLE
Fix bug in textbox number validation

### DIFF
--- a/ui-app/client/src/util/validationProcessor.ts
+++ b/ui-app/client/src/util/validationProcessor.ts
@@ -76,7 +76,7 @@ function EMAIL(validation: any, value: any): Array<string> {
 //}
 
 function NUMBER_VALUE(validation: any, value: any): Array<string> {
-	if (isNullValue(value)) return [];
+	if (isNullValue(value) || value === '') return [];
 	const floatValue = parseFloat(value);
 	if (isNaN(floatValue) || '' + floatValue !== '' + value) return [validation.message];
 	if (!isNullValue(validation.minValue) && floatValue < parseFloat(validation.minValue))


### PR DESCRIPTION
added an empty check to prevent from giving validation error if textbox is empty and number validation is applied