### PR TITLE
feat(iframe): add multiValued support for allow property

### DIFF
--- a/ui-app/client/src/components/Otp/Otp.tsx
+++ b/ui-app/client/src/components/Otp/Otp.tsx
@@ -559,7 +559,7 @@ const component: Component = {
 		type: 'Otp',
 		name: 'Otp',
 		properties: {
-			label: { value: '' },
+			label: { value: 'Otp' },
 		},
 	},
 	validations: {


### PR DESCRIPTION
Enable multiple values for the iframe's allow attribute by setting multiValued to true in the properties definition. This provides more flexibility in configuring iframe permissions.