### PR TITLE
Prompt: craft id-based block merge + agent tool rows / receipt blocks

### DIFF
--- a/ui-app/client/src/components/Prompt/LazyPrompt.tsx
+++ b/ui-app/client/src/components/Prompt/LazyPrompt.tsx
@@ -290,67 +290,38 @@ function processSSEEvent(eventType: string, data: any, ctx: SSEEventContext) {
 			if (!ctx.showToolCalls) break;
 			const tuId = data.tool_use_id ?? '';
 			const msg = data.message ?? '';
-			// v5 (2026-05-25): 3-priority routing.
-			//   P1 — tool_call.id match: this update is for a known tool. Most common path.
-			//   P2 — span.agentToolUseId match: update belongs to a sub-agent's own tuid
-			//        (e.g. AssetPicker's "Picking the best images…"). Surfaces as the agent's
-			//        live status text on its own row — fixes v4's misattribution bug.
-			//   P3 — legacy parentToolUseId match: pre-v5 emits where sub-agents reused
-			//        the parent scrape tool's tuid. Kept for back-compat with old backends.
-			// Counter: window.__promptRouteCounts tracks per-priority hits for telemetry.
-			const w = typeof window !== 'undefined' ? (window as any) : undefined;
-			if (w && !w.__promptRouteCounts) {
-				w.__promptRouteCounts = { p1_tool: 0, p2_agent: 0, p3_legacy: 0, dropped: 0 };
+			// spans win over the direct tool match — legacy updates carry the
+			// SPAWN tool's tuid (also a running toolCall, rendered suppressed).
+			// agent's own tuid (v5) checked before legacy spawn tuid.
+			const spanFor = (field: 'agentToolUseId' | 'parentToolUseId') => {
+				for (const [, span] of ctx.agentSpans) {
+					if (span.status === 'running' && span[field] && span[field] === tuId)
+						return span;
+				}
+				return undefined;
+			};
+			let span = spanFor('agentToolUseId');
+			if (!span) {
+				span = spanFor('parentToolUseId');
+				if (span && !(window as any).__promptLegacyRouteWarned) {
+					(window as any).__promptLegacyRouteWarned = true;
+					// eslint-disable-next-line no-console
+					console.debug(
+						'[prompt] tool_update routed via legacy parentToolUseId (pre-v5 backend)',
+					);
+				}
 			}
-			let routed = false;
-			// P1 — direct tool_call match
+			if (span) {
+				span.statusText = msg;
+				flushMessageState(ctx);
+				break;
+			}
 			const tuTc = ctx.toolCalls.get(tuId);
 			if (tuTc && tuTc.isRunning) {
 				if (!tuTc.updates) tuTc.updates = [];
 				tuTc.updates.push(msg);
-				routed = true;
-				if (w) w.__promptRouteCounts.p1_tool += 1;
 				flushMessageState(ctx);
 			}
-			// P2 — sub-agent's own tool_use_id (v5 path)
-			if (!routed) {
-				for (const [, span] of ctx.agentSpans) {
-					if (
-						span.agentToolUseId &&
-						span.agentToolUseId === tuId &&
-						span.status === 'running'
-					) {
-						span.statusText = msg;
-						routed = true;
-						if (w) w.__promptRouteCounts.p2_agent += 1;
-						flushMessageState(ctx);
-						break;
-					}
-				}
-			}
-			// P3 — legacy parentToolUseId (old backend)
-			if (!routed) {
-				for (const [, span] of ctx.agentSpans) {
-					if (
-						span.parentToolUseId &&
-						span.parentToolUseId === tuId &&
-						span.status === 'running'
-					) {
-						span.statusText = msg;
-						routed = true;
-						if (w) w.__promptRouteCounts.p3_legacy += 1;
-						// eslint-disable-next-line no-console
-						console.debug(
-							'[prompt] tool_update routed via legacy parentToolUseId — ' +
-								'expected in transition window, should trend to 0 after backend rollout.',
-							{ tuId, agentId: span.agentId, label: span.label },
-						);
-						flushMessageState(ctx);
-						break;
-					}
-				}
-			}
-			if (!routed && w) w.__promptRouteCounts.dropped += 1;
 			break;
 		}
 		case 'tool_result': {
@@ -461,49 +432,50 @@ function processSSEEvent(eventType: string, data: any, ctx: SSEEventContext) {
 					let craft: CraftData;
 
 					if (textDelta && next.has(craftId)) {
-						// Stream text into the last text block (or create one)
+						// delta goes to block_id if given, else trailing text block
 						const existing = next.get(craftId)!;
 						const blocks = [...existing.blocks];
-						// Remove callout if present (summary is starting)
-						const lastBlock = blocks[blocks.length - 1];
-						if (lastBlock?.type === 'callout') {
-							blocks.pop();
-						}
-						// Append to existing text block or create new one
-						const lastTextBlock = blocks[blocks.length - 1];
-						if (lastTextBlock?.type === 'text') {
-							blocks[blocks.length - 1] = {
-								...lastTextBlock,
-								content: lastTextBlock.content + textDelta,
+						const targetId = data.block_id;
+						const idx = targetId
+							? blocks.findIndex(b => (b as any).id === targetId)
+							: blocks.length - 1;
+						if (idx >= 0 && blocks[idx]?.type === 'text') {
+							blocks[idx] = {
+								...blocks[idx],
+								content: (blocks[idx].content ?? '') + textDelta,
 							};
 						} else {
-							blocks.push({ type: 'text', content: textDelta });
+							blocks.push({
+								...(targetId ? { id: targetId } : {}),
+								type: 'text',
+								content: textDelta,
+							});
 						}
 						craft = { ...existing, blocks };
 					} else if (isAppend && next.has(craftId)) {
-						// Append blocks. Any new block carrying an `id` that
-						// matches an existing block replaces in place — lets
-						// the backend stream incremental updates (e.g. each
-						// uploaded thumbnail) into the same row without
-						// duplicating blocks.
+						// keyed upsert: same id replaces (even within this batch), no id appends
 						const existing = next.get(craftId)!;
-						const merged = [...existing.blocks];
-						const toAppend: any[] = [];
+						const blocks = [...existing.blocks];
+						const at = new Map<string, number>();
+						blocks.forEach((b, i) => {
+							const bid = (b as any).id;
+							if (bid != null && bid !== '') at.set(String(bid), i);
+						});
 						for (const nb of newBlocks) {
-							const id = (nb as any).id;
-							if (id) {
-								const idx = merged.findIndex(b => (b as any).id === id);
-								if (idx >= 0) {
-									merged[idx] = nb;
-									continue;
-								}
+							const bid = (nb as any).id;
+							const key = bid != null && bid !== '' ? String(bid) : undefined;
+							const idx = key !== undefined ? at.get(key) : undefined;
+							if (idx !== undefined) {
+								blocks[idx] = nb;
+							} else {
+								blocks.push(nb);
+								if (key !== undefined) at.set(key, blocks.length - 1);
 							}
-							toAppend.push(nb);
 						}
 						craft = {
 							...existing,
 							title: data.title ?? existing.title,
-							blocks: [...merged, ...toAppend],
+							blocks,
 						};
 					} else {
 						// Create or replace craft
@@ -521,15 +493,16 @@ function processSSEEvent(eventType: string, data: any, ctx: SSEEventContext) {
 
 				ctx.setActiveCraftId(craftId);
 
-				// Link craft to the assistant message (avoid duplicates)
-				ctx.setMessages(prev =>
-					prev.map(m => {
-						if (m.id !== ctx.assistantMsgId) return m;
-						const existing = m.craftIds ?? [];
-						if (existing.includes(craftId)) return m;
-						return { ...m, craftIds: [...existing, craftId] };
-					}),
-				);
+				// link craft to message; already linked → return prev, no re-render
+				ctx.setMessages(prev => {
+					const m = prev.find(x => x.id === ctx.assistantMsgId);
+					if (!m || m.craftIds?.includes(craftId)) return prev;
+					return prev.map(x =>
+						x.id !== ctx.assistantMsgId
+							? x
+							: { ...x, craftIds: [...(x.craftIds ?? []), craftId] },
+					);
+				});
 			}
 			break;
 		}

--- a/ui-app/client/src/components/Prompt/LazyPrompt.tsx
+++ b/ui-app/client/src/components/Prompt/LazyPrompt.tsx
@@ -69,6 +69,9 @@ interface AgentSpan {
 	label: string;
 	parentId: string;
 	parentToolUseId?: string;
+	// v5 (2026-05-25): this sub-agent's OWN tool_use_id, used by tool_update
+	// routing as the primary key. parentToolUseId is now legacy fallback.
+	agentToolUseId?: string;
 	status: 'running' | 'success' | 'error';
 	startedAt: number;
 	endedAt?: number;
@@ -175,7 +178,6 @@ interface SSEEventContext {
 	setFeedbackTurn: (turn: { sessionId: string; turnNumber: number }) => void;
 	setCrafts: React.Dispatch<React.SetStateAction<Map<string, CraftData>>>;
 	setActiveCraftId: React.Dispatch<React.SetStateAction<string | null>>;
-	setActiveCraft: React.Dispatch<React.SetStateAction<CraftData | null>>;
 	onComplete?: string;
 	completeBindingPath?: string;
 	props: Readonly<ComponentProps>;
@@ -228,6 +230,7 @@ function processSSEEvent(eventType: string, data: any, ctx: SSEEventContext) {
 				label: data.label ?? agentId,
 				parentId: data.parent_id ?? 'root',
 				parentToolUseId: data.parent_tool_use_id || undefined,
+				agentToolUseId: data.agent_tool_use_id || undefined,
 				status: 'running',
 				startedAt: Date.now(),
 				toolCalls: [],
@@ -246,6 +249,10 @@ function processSSEEvent(eventType: string, data: any, ctx: SSEEventContext) {
 				span.tokensOut = data.tokens_out ?? 0;
 				span.stepCount = data.step_count ?? span.toolCalls.length;
 				span.summary = data.summary ?? '';
+				// v5 (2026-05-25): clear lingering statusText only when a summary
+				// is present. If summary is empty (error / no-result), keep the last
+				// statusText so the row still reads as informative on its final state.
+				if (span.summary) span.statusText = undefined;
 				flushMessageState(ctx);
 			}
 			break;
@@ -283,31 +290,67 @@ function processSSEEvent(eventType: string, data: any, ctx: SSEEventContext) {
 			if (!ctx.showToolCalls) break;
 			const tuId = data.tool_use_id ?? '';
 			const msg = data.message ?? '';
-			// Check if this update targets a parent tool that spawned an agent.
-			// If so, show it as the agent's live status text.
+			// v5 (2026-05-25): 3-priority routing.
+			//   P1 — tool_call.id match: this update is for a known tool. Most common path.
+			//   P2 — span.agentToolUseId match: update belongs to a sub-agent's own tuid
+			//        (e.g. AssetPicker's "Picking the best images…"). Surfaces as the agent's
+			//        live status text on its own row — fixes v4's misattribution bug.
+			//   P3 — legacy parentToolUseId match: pre-v5 emits where sub-agents reused
+			//        the parent scrape tool's tuid. Kept for back-compat with old backends.
+			// Counter: window.__promptRouteCounts tracks per-priority hits for telemetry.
+			const w = typeof window !== 'undefined' ? (window as any) : undefined;
+			if (w && !w.__promptRouteCounts) {
+				w.__promptRouteCounts = { p1_tool: 0, p2_agent: 0, p3_legacy: 0, dropped: 0 };
+			}
 			let routed = false;
-			for (const [, span] of ctx.agentSpans) {
-				if (
-					span.parentToolUseId &&
-					span.parentToolUseId === tuId &&
-					span.status === 'running'
-				) {
-					span.statusText = msg;
-					routed = true;
-					flushMessageState(ctx);
-					break;
-				}
+			// P1 — direct tool_call match
+			const tuTc = ctx.toolCalls.get(tuId);
+			if (tuTc && tuTc.isRunning) {
+				if (!tuTc.updates) tuTc.updates = [];
+				tuTc.updates.push(msg);
+				routed = true;
+				if (w) w.__promptRouteCounts.p1_tool += 1;
+				flushMessageState(ctx);
 			}
+			// P2 — sub-agent's own tool_use_id (v5 path)
 			if (!routed) {
-				const tuTc = ctx.toolCalls.get(tuId);
-				if (tuTc && tuTc.isRunning) {
-					// Accumulate updates as a mini-log for expanded view.
-					// Don't replace summary — that's set by tool_result only.
-					if (!tuTc.updates) tuTc.updates = [];
-					tuTc.updates.push(msg);
-					flushMessageState(ctx);
+				for (const [, span] of ctx.agentSpans) {
+					if (
+						span.agentToolUseId &&
+						span.agentToolUseId === tuId &&
+						span.status === 'running'
+					) {
+						span.statusText = msg;
+						routed = true;
+						if (w) w.__promptRouteCounts.p2_agent += 1;
+						flushMessageState(ctx);
+						break;
+					}
 				}
 			}
+			// P3 — legacy parentToolUseId (old backend)
+			if (!routed) {
+				for (const [, span] of ctx.agentSpans) {
+					if (
+						span.parentToolUseId &&
+						span.parentToolUseId === tuId &&
+						span.status === 'running'
+					) {
+						span.statusText = msg;
+						routed = true;
+						if (w) w.__promptRouteCounts.p3_legacy += 1;
+						// eslint-disable-next-line no-console
+						console.debug(
+							'[prompt] tool_update routed via legacy parentToolUseId — ' +
+								'expected in transition window, should trend to 0 after backend rollout.',
+							{ tuId, agentId: span.agentId, label: span.label },
+						);
+						flushMessageState(ctx);
+						break;
+					}
+				}
+			}
+			if (!routed && w) w.__promptRouteCounts.dropped += 1;
 			break;
 		}
 		case 'tool_result': {
@@ -438,12 +481,29 @@ function processSSEEvent(eventType: string, data: any, ctx: SSEEventContext) {
 						}
 						craft = { ...existing, blocks };
 					} else if (isAppend && next.has(craftId)) {
-						// Append blocks to existing craft
+						// Append blocks. Any new block carrying an `id` that
+						// matches an existing block replaces in place — lets
+						// the backend stream incremental updates (e.g. each
+						// uploaded thumbnail) into the same row without
+						// duplicating blocks.
 						const existing = next.get(craftId)!;
+						const merged = [...existing.blocks];
+						const toAppend: any[] = [];
+						for (const nb of newBlocks) {
+							const id = (nb as any).id;
+							if (id) {
+								const idx = merged.findIndex(b => (b as any).id === id);
+								if (idx >= 0) {
+									merged[idx] = nb;
+									continue;
+								}
+							}
+							toAppend.push(nb);
+						}
 						craft = {
 							...existing,
 							title: data.title ?? existing.title,
-							blocks: [...existing.blocks, ...newBlocks],
+							blocks: [...merged, ...toAppend],
 						};
 					} else {
 						// Create or replace craft
@@ -456,7 +516,6 @@ function processSSEEvent(eventType: string, data: any, ctx: SSEEventContext) {
 					}
 
 					next.set(craftId, craft);
-					ctx.setActiveCraft(craft);
 					return next;
 				});
 
@@ -827,7 +886,10 @@ export default function LazyPrompt(props: Readonly<ComponentProps>) {
 	// Craft panel state
 	const [crafts, setCrafts] = useState<Map<string, CraftData>>(new Map());
 	const [activeCraftId, setActiveCraftId] = useState<string | null>(null);
-	const [activeCraft, setActiveCraft] = useState<CraftData | null>(null);
+	// Derive activeCraft from the crafts Map so it never drifts out of sync.
+	// (Previously a separate useState updated inside setCrafts' updater — a
+	// React anti-pattern that caused appended blocks to occasionally drop.)
+	const activeCraft = activeCraftId ? crafts.get(activeCraftId) ?? null : null;
 
 	// Model selector state
 	const [availableModels, setAvailableModels] = useState<{ id: string; name: string }[]>([]);
@@ -1442,6 +1504,12 @@ export default function LazyPrompt(props: Readonly<ComponentProps>) {
 					}
 				}, 5_000);
 
+				// eventType is preserved across reader.read() chunks because a
+				// single SSE event ("event: foo\ndata: ...\n\n") can be split
+				// at any byte boundary. Resetting per-chunk dropped the data
+				// line whenever a network read landed between the header and
+				// the data, intermittently silently losing craft events.
+				let eventType = '';
 				try {
 					while (true) {
 						const { done, value } = await reader.read();
@@ -1451,8 +1519,6 @@ export default function LazyPrompt(props: Readonly<ComponentProps>) {
 						buffer += decoder.decode(value, { stream: true });
 						const lines = buffer.split('\n');
 						buffer = lines.pop() ?? '';
-
-						let eventType = '';
 
 						for (const line of lines) {
 							if (line.startsWith('event: ')) {
@@ -1478,7 +1544,6 @@ export default function LazyPrompt(props: Readonly<ComponentProps>) {
 										setFeedbackTurn: turn => setFeedbackTurn(turn),
 										setCrafts,
 										setActiveCraftId,
-										setActiveCraft,
 										onComplete,
 										completeBindingPath,
 										props,
@@ -1951,10 +2016,7 @@ export default function LazyPrompt(props: Readonly<ComponentProps>) {
 									key={c.id}
 									title={c.title}
 									subtitle={subtitle}
-									onClick={() => {
-										setActiveCraftId(c.id);
-										setActiveCraft(c);
-									}}
+									onClick={() => setActiveCraftId(c.id)}
 									definition={props.definition}
 									styleProperties={styleProperties}
 								/>
@@ -2036,10 +2098,7 @@ export default function LazyPrompt(props: Readonly<ComponentProps>) {
 			{activeCraft && (
 				<CraftPanel
 					craft={activeCraft}
-					onClose={() => {
-						setActiveCraftId(null);
-						setActiveCraft(null);
-					}}
+					onClose={() => setActiveCraftId(null)}
 					definition={props.definition}
 					styleProperties={styleProperties}
 				/>

--- a/ui-app/client/src/components/Prompt/PromptStyle.tsx
+++ b/ui-app/client/src/components/Prompt/PromptStyle.tsx
@@ -899,12 +899,18 @@ export default function PromptStyle({
 			border-radius: 6px;
 		}
 
-		${PREFIX} ._agentToolHeader._clickable {
-			cursor: pointer;
+		${PREFIX} ._agentToolDot {
+			width: 6px;
+			height: 6px;
+			border-radius: 50%;
+			background: #1a1a1a;
+			flex-shrink: 0;
+			animation: _agentToolPulse 1.4s ease-in-out infinite;
 		}
 
-		${PREFIX} ._agentToolHeader._clickable:hover {
-			background: #f4f4f4;
+		@keyframes _agentToolPulse {
+			0%, 100% { opacity: 0.35; }
+			50% { opacity: 1; }
 		}
 
 		${PREFIX} ._agentToolLabel {
@@ -919,16 +925,38 @@ export default function PromptStyle({
 
 		${PREFIX} ._agentToolSummary {
 			color: #9b9b9b;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
 			flex: 1;
 			min-width: 0;
 			font-size: 12px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		${PREFIX} ._agentToolBody {
+			max-height: 200px;
+			overflow-y: auto;
+			white-space: pre-wrap;
+			word-break: break-word;
+			padding: 8px 10px;
+			margin: 4px 0 4px 22px;
+			background: #f8f8f8;
+			border-radius: 6px;
+			font-size: 12px;
+			color: #555;
+			line-height: 1.6;
+		}
+
+		${PREFIX} ._agentToolHeader._clickable {
+			cursor: pointer;
+		}
+
+		${PREFIX} ._agentToolHeader._clickable:hover ._agentToolName {
+			color: #000;
 		}
 
 		${PREFIX} ._agentToolToggle {
-			font-size: 9px;
+			font-size: 10px;
 			color: #9b9b9b;
 			flex-shrink: 0;
 			margin-left: auto;
@@ -1363,6 +1391,123 @@ export default function PromptStyle({
 
 		${PREFIX} ._craftRow > * {
 			flex: 1;
+		}
+
+		/* Empty placeholders for receipt blocks (assets_label / assets_row)
+		   are emitted by the scrape pipeline so the layout order is fixed
+		   from the first paint; we hide them until the agent fills them in. */
+		${PREFIX} ._craftRow:empty {
+			display: none;
+		}
+		${PREFIX} ._craftText:empty {
+			display: none;
+		}
+
+		/* Collapsible block — generic single-line summary + toggleable body.
+		   Any agent can use it to surface optional detail without bloating
+		   the craft canvas. */
+		${PREFIX} ._craftCollapsible {
+			border-top: 1px solid #eee;
+			border-bottom: 1px solid #eee;
+			margin: 4px 0;
+		}
+
+		${PREFIX} ._craftCollapsibleHeader {
+			width: 100%;
+			display: flex;
+			align-items: center;
+			gap: 10px;
+			padding: 10px 2px;
+			background: none;
+			border: none;
+			cursor: pointer;
+			font-size: 13px;
+			color: #555;
+			text-align: left;
+		}
+
+		${PREFIX} ._craftCollapsibleHeader:hover {
+			color: #1a1a1a;
+		}
+
+		${PREFIX} ._craftCollapsibleGlyph {
+			font-size: 14px;
+			color: #888;
+			line-height: 1;
+		}
+
+		${PREFIX} ._craftCollapsibleSummary {
+			flex: 1;
+		}
+
+		${PREFIX} ._craftCollapsibleChevron {
+			font-size: 16px;
+			color: #999;
+			line-height: 1;
+			transition: transform 0.15s ease;
+			display: inline-block;
+		}
+
+		${PREFIX} ._craftCollapsibleChevron._open {
+			transform: rotate(90deg);
+		}
+
+		${PREFIX} ._craftCollapsibleBody {
+			display: flex;
+			flex-direction: column;
+			gap: 12px;
+			padding: 4px 2px 12px;
+		}
+
+		/* Thumbnail variant of image block — fixed 48px square, contain (not
+		   cover) so logos with transparent backgrounds render correctly.
+		   Explicit flex override so a parent _craftRow flex-1 rule does
+		   not stretch these. */
+		${PREFIX} ._craftImage._thumbnail {
+			display: inline-block;
+			width: 48px;
+			height: 48px;
+			flex: 0 0 48px;
+		}
+
+		${PREFIX} ._craftImage._thumbnail a {
+			display: block;
+			width: 100%;
+			height: 100%;
+			border: 1px solid #e5e5e5;
+			border-radius: 8px;
+			overflow: hidden;
+			background: #fafafa;
+		}
+
+		${PREFIX} ._craftImage._thumbnail img {
+			width: 100%;
+			height: 100%;
+			object-fit: contain;
+			aspect-ratio: auto;
+			border-radius: 0;
+			background: transparent;
+		}
+
+		/* Dark variant of the thumbnail tile — for white/transparent content
+		   that would otherwise vanish on a light background. */
+		${PREFIX} ._craftImage._thumbnail._dark a {
+			background: #1a1a1a;
+			border-color: #333;
+		}
+
+		/* Light variant — explicit (matches default) so dark-on-transparent
+		   content reads. Same as default but documented for symmetry with
+		   the dark hint. */
+		${PREFIX} ._craftImage._thumbnail._light a {
+			background: #fafafa;
+			border-color: #e5e5e5;
+		}
+
+		/* Cover variant — for photo-style images that should fill the tile
+		   without letterboxing. Use for creative/hero thumbnails. */
+		${PREFIX} ._craftImage._thumbnail._cover img {
+			object-fit: cover;
 		}
 
 		/* ─── Craft Panel responsive ─── */

--- a/ui-app/client/src/components/Prompt/PromptStyle.tsx
+++ b/ui-app/client/src/components/Prompt/PromptStyle.tsx
@@ -800,6 +800,10 @@ export default function PromptStyle({
 			background: transparent;
 			border: 1.5px solid #1a1a1a;
 		}
+		${PREFIX} ._statusDot._sm {
+			width: 6px;
+			height: 6px;
+		}
 		@keyframes promptStatusDotPulse {
 			0%, 100% { opacity: 1; transform: scale(1); }
 			50%      { opacity: 0.25; transform: scale(0.75); }
@@ -899,20 +903,6 @@ export default function PromptStyle({
 			border-radius: 6px;
 		}
 
-		${PREFIX} ._agentToolDot {
-			width: 6px;
-			height: 6px;
-			border-radius: 50%;
-			background: #1a1a1a;
-			flex-shrink: 0;
-			animation: _agentToolPulse 1.4s ease-in-out infinite;
-		}
-
-		@keyframes _agentToolPulse {
-			0%, 100% { opacity: 0.35; }
-			50% { opacity: 1; }
-		}
-
 		${PREFIX} ._agentToolLabel {
 			font-size: 12px;
 			color: #8b8b8b;
@@ -933,18 +923,8 @@ export default function PromptStyle({
 			white-space: nowrap;
 		}
 
-		${PREFIX} ._agentToolBody {
-			max-height: 200px;
-			overflow-y: auto;
-			white-space: pre-wrap;
-			word-break: break-word;
-			padding: 8px 10px;
+		${PREFIX} ._agentToolRow ._agentToolDetail {
 			margin: 4px 0 4px 22px;
-			background: #f8f8f8;
-			border-radius: 6px;
-			font-size: 12px;
-			color: #555;
-			line-height: 1.6;
 		}
 
 		${PREFIX} ._agentToolHeader._clickable {
@@ -980,16 +960,6 @@ export default function PromptStyle({
 			font-size: 12px;
 			color: #9b9b9b;
 			font-style: italic;
-		}
-
-		${PREFIX} ._agentToolExpanded {
-			display: flex;
-			flex-direction: column;
-			gap: 2px;
-			padding-left: 12px;
-			margin: 2px 0 4px;
-			border-left: 1px solid #e5e5e5;
-			margin-left: 8px;
 		}
 
 		${PREFIX} ._agentToolUpdates {
@@ -1193,6 +1163,42 @@ export default function PromptStyle({
 			height: 100%;
 			background: #fff;
 			overflow: hidden;
+			position: relative;
+		}
+
+		${PREFIX} ._craftJumpDown {
+			position: absolute;
+			bottom: 16px;
+			left: 50%;
+			transform: translateX(-50%);
+			width: 32px;
+			height: 32px;
+			border-radius: 50%;
+			background: #fff;
+			border: 1px solid #ddd;
+			color: #333;
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+			cursor: pointer;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			font-size: 12px;
+			animation: _craftJumpIn 0.15s ease-out;
+		}
+
+		${PREFIX} ._craftJumpDown:hover {
+			background: #f5f5f5;
+		}
+
+		@keyframes _craftJumpIn {
+			from {
+				opacity: 0;
+				transform: translate(-50%, 4px);
+			}
+			to {
+				opacity: 1;
+				transform: translate(-50%, 0);
+			}
 		}
 
 		${PREFIX} ._craftPanelHeader {
@@ -1393,11 +1399,8 @@ export default function PromptStyle({
 			flex: 1;
 		}
 
-		/* hide placeholder blocks emitted empty (layout order fixed at first paint) */
-		${PREFIX} ._craftRow:empty {
-			display: none;
-		}
-		${PREFIX} ._craftText:empty {
+		/* a divider with nothing after it (section never filled) is noise */
+		${PREFIX} ._craftContent > ._craftDivider:last-child {
 			display: none;
 		}
 
@@ -1492,14 +1495,6 @@ export default function PromptStyle({
 		${PREFIX} ._craftImage._thumbnail._dark a {
 			background: #1a1a1a;
 			border-color: #333;
-		}
-
-		/* Light variant — explicit (matches default) so dark-on-transparent
-		   content reads. Same as default but documented for symmetry with
-		   the dark hint. */
-		${PREFIX} ._craftImage._thumbnail._light a {
-			background: #fafafa;
-			border-color: #e5e5e5;
 		}
 
 		/* Cover variant — for photo-style images that should fill the tile

--- a/ui-app/client/src/components/Prompt/PromptStyle.tsx
+++ b/ui-app/client/src/components/Prompt/PromptStyle.tsx
@@ -1393,9 +1393,7 @@ export default function PromptStyle({
 			flex: 1;
 		}
 
-		/* Empty placeholders for receipt blocks (assets_label / assets_row)
-		   are emitted by the scrape pipeline so the layout order is fixed
-		   from the first paint; we hide them until the agent fills them in. */
+		/* hide placeholder blocks emitted empty (layout order fixed at first paint) */
 		${PREFIX} ._craftRow:empty {
 			display: none;
 		}

--- a/ui-app/client/src/components/Prompt/PromptStyle.tsx
+++ b/ui-app/client/src/components/Prompt/PromptStyle.tsx
@@ -1259,6 +1259,9 @@ export default function PromptStyle({
 			margin: 0;
 			font-size: 14px;
 			line-height: 1.6;
+			/* flush right edge — streaming rag doesn't dance */
+			text-align: justify;
+			hyphens: auto;
 		}
 
 		${PREFIX} ._craftBadge {

--- a/ui-app/client/src/components/Prompt/components/AgentGroup.tsx
+++ b/ui-app/client/src/components/Prompt/components/AgentGroup.tsx
@@ -90,14 +90,15 @@ function AgentRow({
 	const elapsed = elapsedSeconds(sp, now);
 	const hasBody = sp.toolCalls.length > 0 || !!sp.statusText;
 
-	// Right-side meta: summary when done, statusText when processing, elapsed always.
-	// cap summary at 40ch — long strings break row layout
+	// right meta: summary when done (falls back to last statusText so error
+	// rows aren't blank), elapsed always. 40ch cap — long strings break layout
 	const SUMMARY_CAP = 40;
 	let rightMeta = `${elapsed}s`;
-	if (sp.status !== 'running' && sp.summary) {
-		const s = sp.summary.length > SUMMARY_CAP
-			? sp.summary.slice(0, SUMMARY_CAP - 1) + '…'
-			: sp.summary;
+	const finalText = sp.status !== 'running' ? sp.summary || sp.statusText : '';
+	if (finalText) {
+		const s = finalText.length > SUMMARY_CAP
+			? finalText.slice(0, SUMMARY_CAP - 1) + '…'
+			: finalText;
 		rightMeta = `${s}  ${elapsed}s`;
 	}
 
@@ -127,8 +128,9 @@ function AgentRow({
 						const inlineText = tc.isRunning ? latest : (tc.summary || latest);
 						const canExpand =
 							!tc.isRunning &&
-							!!tc.summary &&
-							(tc.summary.includes('\n') || tc.summary.length > 80);
+							(updates.length > 1 ||
+								(!!tc.summary &&
+									(tc.summary.includes('\n') || tc.summary.length > 80)));
 						const isOpen = openSummaries.has(tc.id);
 						const rowClasses = [
 							'_agentToolRow',
@@ -138,7 +140,7 @@ function AgentRow({
 						].filter(Boolean).join(' ');
 						const headerInner = (
 							<>
-								{tc.isRunning && <span className="_agentToolDot" />}
+								{tc.isRunning && <span className="_statusDot _running _sm" />}
 								<span className="_agentToolLabel">
 									Tool(<span className="_agentToolName">{label}</span>)
 								</span>
@@ -169,7 +171,14 @@ function AgentRow({
 									<div className="_agentToolHeader">{headerInner}</div>
 								)}
 								{canExpand && isOpen && (
-									<div className="_agentToolBody">{inlineText}</div>
+									<div className="_agentToolDetail">
+										{updates.map((u, i) => (
+											<div key={i} className="_agentToolUpdateLine">
+												{u}
+											</div>
+										))}
+										{tc.summary && <div>{tc.summary}</div>}
+									</div>
 								)}
 							</div>
 						);

--- a/ui-app/client/src/components/Prompt/components/AgentGroup.tsx
+++ b/ui-app/client/src/components/Prompt/components/AgentGroup.tsx
@@ -60,8 +60,9 @@ function AgentRow({
 	const isRunning = sp.status === 'running';
 	const [expanded, setExpanded] = useState(isRunning);
 	const [userToggled, setUserToggled] = useState(false);
-	// Accordion: only one tool expanded at a time. null = all collapsed.
-	const [expandedToolId, setExpandedToolId] = useState<string | null>(null);
+	// Tool rows that have been clicked open to view the full summary. Running
+	// rows are never in this set — progress is ephemeral and shouldn't expand.
+	const [openSummaries, setOpenSummaries] = useState<Set<string>>(new Set());
 
 	useEffect(() => {
 		if (userToggled) return;
@@ -72,29 +73,35 @@ function AgentRow({
 		}
 	}, [isRunning, userToggled]);
 
-	// Auto-expand the latest running tool; close when next one starts.
-	useEffect(() => {
-		if (!isRunning) return;
-		const lastRunning = [...sp.toolCalls].reverse().find(tc => tc.isRunning);
-		if (lastRunning) setExpandedToolId(lastRunning.id);
-	}, [isRunning, sp.toolCalls]);
-
 	const toggle = useCallback(() => {
 		setUserToggled(true);
 		setExpanded(prev => !prev);
 	}, []);
 
-	const toggleTool = useCallback((toolId: string) => {
-		setExpandedToolId(prev => prev === toolId ? null : toolId);
+	const toggleSummary = useCallback((id: string) => {
+		setOpenSummaries(prev => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
 	}, []);
 
 	const elapsed = elapsedSeconds(sp, now);
 	const hasBody = sp.toolCalls.length > 0 || !!sp.statusText;
 
-	// Right-side meta: summary when done, statusText when processing, elapsed always
+	// Right-side meta: summary when done, statusText when processing, elapsed always.
+	// Defensive cap (rightMeta-overflow fix · 2026-05-27): the backend contract is
+	// "summary = a span outcome users can't derive elsewhere" (see SummaryAgent's
+	// _emit_finished docstring), but a misbehaving caller can still ship a long
+	// string. Truncate to 40 chars with ellipsis so the row layout can't break.
+	const SUMMARY_CAP = 40;
 	let rightMeta = `${elapsed}s`;
 	if (sp.status !== 'running' && sp.summary) {
-		rightMeta = `${sp.summary}  ${elapsed}s`;
+		const s = sp.summary.length > SUMMARY_CAP
+			? sp.summary.slice(0, SUMMARY_CAP - 1) + '…'
+			: sp.summary;
+		rightMeta = `${s}  ${elapsed}s`;
 	}
 
 	return (
@@ -117,57 +124,55 @@ function AgentRow({
 			{expanded && hasBody && (
 				<div className="_agentRowBody">
 					{sp.toolCalls.map(tc => {
-						const isToolOpen = expandedToolId === tc.id;
 						const label = tc.displayName || tc.toolName;
-						const updateCount = tc.updates?.length ?? 0;
-						// Collapsed text: final summary if done, else count/last-update while running
-						let collapsedText = tc.summary || '';
-						if (!collapsedText && updateCount > 1) {
-							collapsedText = `${updateCount} operations`;
-						} else if (!collapsedText && updateCount === 1) {
-							collapsedText = tc.updates![0];
-						}
-						const hasDetail = !!collapsedText || updateCount > 0;
+						const updates = tc.updates ?? [];
+						const latest = updates.length ? updates[updates.length - 1] : '';
+						const inlineText = tc.isRunning ? latest : (tc.summary || latest);
+						const canExpand =
+							!tc.isRunning &&
+							!!tc.summary &&
+							(tc.summary.includes('\n') || tc.summary.length > 80);
+						const isOpen = openSummaries.has(tc.id);
+						const rowClasses = [
+							'_agentToolRow',
+							tc.isRunning && '_running',
+							canExpand && '_expandable',
+							isOpen && '_open',
+						].filter(Boolean).join(' ');
+						const headerInner = (
+							<>
+								{tc.isRunning && <span className="_agentToolDot" />}
+								<span className="_agentToolLabel">
+									Tool(<span className="_agentToolName">{label}</span>)
+								</span>
+								{/* Inline peek only when closed; expanded body lives below. */}
+								{!isOpen && inlineText && (
+									<span className="_agentToolSummary">{inlineText}</span>
+								)}
+								{canExpand && (
+									<i
+										className={`_agentToolToggle ${isOpen ? collapseIcon : expandIcon}`}
+										aria-hidden="true"
+									/>
+								)}
+							</>
+						);
 						return (
-							<div key={tc.id} className="_agentToolRow">
-								{hasDetail ? (
+							<div key={tc.id} className={rowClasses}>
+								{canExpand ? (
 									<button
 										type="button"
 										className="_agentToolHeader _clickable"
-										onClick={() => toggleTool(tc.id)}
+										onClick={() => toggleSummary(tc.id)}
+										aria-expanded={isOpen}
 									>
-										<span className="_agentToolLabel">
-											Tool(<span className="_agentToolName">{label}</span>)
-										</span>
-										{!isToolOpen && collapsedText && (
-											<span className="_agentToolSummary">
-												{collapsedText.length > 80
-													? collapsedText.slice(0, 80) + '...'
-													: collapsedText}
-											</span>
-										)}
-										<i className={`_agentToolToggle ${isToolOpen ? collapseIcon : expandIcon}`} />
+										{headerInner}
 									</button>
 								) : (
-									<div className="_agentToolHeader">
-										<span className="_agentToolLabel">
-											Tool(<span className="_agentToolName">{label}</span>)
-										</span>
-									</div>
+									<div className="_agentToolHeader">{headerInner}</div>
 								)}
-								{isToolOpen && (
-									<div className="_agentToolExpanded">
-										{tc.updates?.length ? (
-											<div className="_agentToolUpdates">
-												{tc.updates.map((u, i) => (
-													<div key={i} className="_agentToolUpdateLine">{u}</div>
-												))}
-											</div>
-										) : null}
-										{tc.summary && tc.summary !== tc.updates?.[tc.updates.length - 1] && (
-											<div className="_agentToolDetail">{tc.summary}</div>
-										)}
-									</div>
+								{canExpand && isOpen && (
+									<div className="_agentToolBody">{inlineText}</div>
 								)}
 							</div>
 						);

--- a/ui-app/client/src/components/Prompt/components/AgentGroup.tsx
+++ b/ui-app/client/src/components/Prompt/components/AgentGroup.tsx
@@ -91,10 +91,7 @@ function AgentRow({
 	const hasBody = sp.toolCalls.length > 0 || !!sp.statusText;
 
 	// Right-side meta: summary when done, statusText when processing, elapsed always.
-	// Defensive cap (rightMeta-overflow fix · 2026-05-27): the backend contract is
-	// "summary = a span outcome users can't derive elsewhere" (see SummaryAgent's
-	// _emit_finished docstring), but a misbehaving caller can still ship a long
-	// string. Truncate to 40 chars with ellipsis so the row layout can't break.
+	// cap summary at 40ch — long strings break row layout
 	const SUMMARY_CAP = 40;
 	let rightMeta = `${elapsed}s`;
 	if (sp.status !== 'running' && sp.summary) {

--- a/ui-app/client/src/components/Prompt/components/CraftPanel.tsx
+++ b/ui-app/client/src/components/Prompt/components/CraftPanel.tsx
@@ -24,14 +24,21 @@ export function CraftPanel({
 	styleProperties,
 }: Readonly<CraftPanelProps>) {
 	const bodyRef = useRef<HTMLDivElement>(null);
+	const prevBlockCount = useRef(0);
 
-	// Auto-scroll to bottom as content streams in
+	// Auto-scroll on content change. Two modes:
+	//   - text streaming (block count unchanged): only scroll if user was
+	//     already at the bottom — respects their position if they scrolled up.
+	//   - new block appended (block count grew): always scroll, so emitted
+	//     content (e.g. asset receipts appended after summary) is visible.
 	useEffect(() => {
 		const el = bodyRef.current;
 		if (!el) return;
-		// Only auto-scroll if user is near the bottom (within 100px)
+		const blocksGrew = craft.blocks.length > prevBlockCount.current;
+		prevBlockCount.current = craft.blocks.length;
+
 		const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
-		if (isNearBottom) {
+		if (blocksGrew || isNearBottom) {
 			el.scrollTop = el.scrollHeight;
 		}
 	}, [craft.blocks]);

--- a/ui-app/client/src/components/Prompt/components/CraftPanel.tsx
+++ b/ui-app/client/src/components/Prompt/components/CraftPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ComponentDefinition } from '../../../types/common';
 import { SubHelperComponent } from '../../HelperComponents/SubHelperComponent';
 import { CraftRenderer } from './CraftRenderer';
@@ -24,38 +24,37 @@ export function CraftPanel({
 	styleProperties,
 }: Readonly<CraftPanelProps>) {
 	const bodyRef = useRef<HTMLDivElement>(null);
-	const prevBlockCount = useRef(0);
-	const craftIdRef = useRef(craft.id);
-	// stick = user at/near bottom. written only on wheel/touch (human-only
-	// events) — smooth glide fires scroll events but never these, can't unstick itself.
-	const stickToBottomRef = useRef(true);
+	const craftIdRef = useRef<string | null>(null);
+	// at bottom → follow new content; scrolled up (any way) → never yank
+	const stickRef = useRef(true);
+	// pill shown ⇔ content below; no pill = you're at the end
+	const [belowFold, setBelowFold] = useState(false);
 
-	const noteUserScroll = () => {
-		// rAF: wheel fires before scrollTop updates
-		requestAnimationFrame(() => {
-			const el = bodyRef.current;
-			if (!el) return;
-			stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
-		});
+	const measure = () => {
+		const el = bodyRef.current;
+		if (!el) return;
+		const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+		stickRef.current = atBottom;
+		setBelowFold(!atBottom);
 	};
 
-	// scroll when: sticking · new block appended · craft switched
 	useEffect(() => {
 		const el = bodyRef.current;
 		if (!el) return;
 		const isNewCraft = craftIdRef.current !== craft.id;
 		craftIdRef.current = craft.id;
-		const blocksGrew = !isNewCraft && craft.blocks.length > prevBlockCount.current;
-		prevBlockCount.current = craft.blocks.length;
-
-		if (isNewCraft || blocksGrew || stickToBottomRef.current) {
-			const gap = el.scrollHeight - el.scrollTop - el.clientHeight;
-			// glide big jumps; snap small growth (fast deltas can't stack glides) + craft switch
-			const behavior = !isNewCraft && gap > 150 ? 'smooth' : 'auto';
-			el.scrollTo({ top: el.scrollHeight, behavior });
-			stickToBottomRef.current = true;
-		}
+		// open/switch lands at end; sticking follows new content
+		if (isNewCraft || stickRef.current) el.scrollTop = el.scrollHeight;
+		measure();
 	}, [craft.id, craft.blocks]);
+
+	const jumpToBottom = () => {
+		// stick resumes via onScroll when the glide hits bottom
+		bodyRef.current?.scrollTo({
+			top: bodyRef.current.scrollHeight,
+			behavior: 'smooth',
+		});
+	};
 
 	return (
 		<div className="_craftPanel" style={styleProperties?.craftPanel ?? {}}>
@@ -78,18 +77,23 @@ export function CraftPanel({
 					<i className="fa fa-xmark" />
 				</button>
 			</div>
-			<div
-				className="_craftPanelBody"
-				ref={bodyRef}
-				onWheel={noteUserScroll}
-				onTouchMove={noteUserScroll}
-			>
+			<div className="_craftPanelBody" ref={bodyRef} onScroll={measure}>
 				<CraftRenderer
 					blocks={craft.blocks}
 					definition={definition}
 					styleProperties={styleProperties}
 				/>
 			</div>
+			{belowFold && (
+				<button
+					type="button"
+					className="_craftJumpDown"
+					onClick={jumpToBottom}
+					title="Jump to latest"
+				>
+					<i className="fa fa-chevron-down" />
+				</button>
+			)}
 		</div>
 	);
 }

--- a/ui-app/client/src/components/Prompt/components/CraftPanel.tsx
+++ b/ui-app/client/src/components/Prompt/components/CraftPanel.tsx
@@ -25,23 +25,37 @@ export function CraftPanel({
 }: Readonly<CraftPanelProps>) {
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const prevBlockCount = useRef(0);
+	const craftIdRef = useRef(craft.id);
+	// stick = user at/near bottom. written only on wheel/touch (human-only
+	// events) — smooth glide fires scroll events but never these, can't unstick itself.
+	const stickToBottomRef = useRef(true);
 
-	// Auto-scroll on content change. Two modes:
-	//   - text streaming (block count unchanged): only scroll if user was
-	//     already at the bottom — respects their position if they scrolled up.
-	//   - new block appended (block count grew): always scroll, so emitted
-	//     content (e.g. asset receipts appended after summary) is visible.
+	const noteUserScroll = () => {
+		// rAF: wheel fires before scrollTop updates
+		requestAnimationFrame(() => {
+			const el = bodyRef.current;
+			if (!el) return;
+			stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+		});
+	};
+
+	// scroll when: sticking · new block appended · craft switched
 	useEffect(() => {
 		const el = bodyRef.current;
 		if (!el) return;
-		const blocksGrew = craft.blocks.length > prevBlockCount.current;
+		const isNewCraft = craftIdRef.current !== craft.id;
+		craftIdRef.current = craft.id;
+		const blocksGrew = !isNewCraft && craft.blocks.length > prevBlockCount.current;
 		prevBlockCount.current = craft.blocks.length;
 
-		const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
-		if (blocksGrew || isNearBottom) {
-			el.scrollTop = el.scrollHeight;
+		if (isNewCraft || blocksGrew || stickToBottomRef.current) {
+			const gap = el.scrollHeight - el.scrollTop - el.clientHeight;
+			// glide big jumps; snap small growth (fast deltas can't stack glides) + craft switch
+			const behavior = !isNewCraft && gap > 150 ? 'smooth' : 'auto';
+			el.scrollTo({ top: el.scrollHeight, behavior });
+			stickToBottomRef.current = true;
 		}
-	}, [craft.blocks]);
+	}, [craft.id, craft.blocks]);
 
 	return (
 		<div className="_craftPanel" style={styleProperties?.craftPanel ?? {}}>
@@ -64,7 +78,12 @@ export function CraftPanel({
 					<i className="fa fa-xmark" />
 				</button>
 			</div>
-			<div className="_craftPanelBody" ref={bodyRef}>
+			<div
+				className="_craftPanelBody"
+				ref={bodyRef}
+				onWheel={noteUserScroll}
+				onTouchMove={noteUserScroll}
+			>
 				<CraftRenderer
 					blocks={craft.blocks}
 					definition={definition}

--- a/ui-app/client/src/components/Prompt/components/CraftRenderer.tsx
+++ b/ui-app/client/src/components/Prompt/components/CraftRenderer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ComponentDefinition } from '../../../types/common';
 import { SubHelperComponent } from '../../HelperComponents/SubHelperComponent';
 
@@ -54,11 +54,34 @@ function KeyValueBlock({ items }: { items: Array<{ key: string; value: string }>
 	);
 }
 
-function ImageBlock({ url, caption }: { url: string; caption?: string }) {
+function ImageBlock({
+	url,
+	thumb_url,
+	caption,
+	size,
+	background,
+	fit,
+}: {
+	url: string;
+	thumb_url?: string;
+	caption?: string;
+	size?: 'thumbnail';
+	background?: 'dark' | 'light';
+	fit?: 'cover' | 'contain';
+}) {
+	const classes = ['_craftImage'];
+	if (size === 'thumbnail') classes.push('_thumbnail');
+	if (background === 'dark') classes.push('_dark');
+	if (background === 'light') classes.push('_light');
+	if (fit === 'cover') classes.push('_cover');
+	// Render the thumbnail inline (bandwidth-friendly for the 48px tile) but
+	// link to the full-resolution URL on click. When no thumb is supplied the
+	// inline image falls back to the full URL.
+	const inlineSrc = thumb_url || url;
 	return (
-		<div className="_craftImage">
+		<div className={classes.join(' ')}>
 			<a href={url} target="_blank" rel="noopener noreferrer" title="Click to view full size">
-				<img src={url} alt={caption ?? ''} loading="lazy" />
+				<img src={inlineSrc} alt={caption ?? ''} loading="lazy" />
 			</a>
 			{caption && <span className="_craftImageCaption">{caption}</span>}
 		</div>
@@ -157,6 +180,54 @@ function RowBlock({
 	);
 }
 
+function CollapsibleBlock({
+	summary,
+	glyph,
+	children = [],
+	default_expanded,
+	styleProperties,
+}: {
+	summary: string;
+	glyph?: string;
+	children?: Block[];
+	default_expanded?: boolean;
+	styleProperties?: any;
+}) {
+	const [expanded, setExpanded] = useState(Boolean(default_expanded));
+	if (!summary && (!children || children.length === 0)) return null;
+
+	return (
+		<div className="_craftCollapsible">
+			<button
+				type="button"
+				className="_craftCollapsibleHeader"
+				onClick={() => setExpanded(prev => !prev)}
+				aria-expanded={expanded}
+			>
+				{glyph && <span className="_craftCollapsibleGlyph">{glyph}</span>}
+				<span className="_craftCollapsibleSummary">{summary}</span>
+				<span
+					className={`_craftCollapsibleChevron ${expanded ? '_open' : ''}`}
+					aria-hidden="true"
+				>
+					›
+				</span>
+			</button>
+			{expanded && (
+				<div className="_craftCollapsibleBody">
+					{children.map((block, i) => (
+						<CraftBlockRenderer
+							key={i}
+							block={block}
+							styleProperties={styleProperties}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
 const BLOCK_RENDERERS: Record<string, React.FC<any>> = {
 	heading: HeadingBlock,
 	text: TextBlock,
@@ -169,6 +240,7 @@ const BLOCK_RENDERERS: Record<string, React.FC<any>> = {
 	callout: CalloutBlock,
 	list: ListBlock,
 	row: RowBlock,
+	collapsible: CollapsibleBlock,
 };
 
 function CraftBlockRenderer({

--- a/ui-app/client/src/components/Prompt/components/CraftRenderer.tsx
+++ b/ui-app/client/src/components/Prompt/components/CraftRenderer.tsx
@@ -12,7 +12,9 @@ function HeadingBlock({ text, level = 1 }: { text: string; level?: number }) {
 	return <Tag className="_craftHeading">{text}</Tag>;
 }
 
+// empty block = unfilled placeholder (seeded for layout, filled later by id) — don't paint
 function TextBlock({ content }: { content: string }) {
+	if (!content) return null;
 	return <p className="_craftText">{content}</p>;
 }
 
@@ -69,20 +71,28 @@ function ImageBlock({
 	background?: 'dark' | 'light';
 	fit?: 'cover' | 'contain';
 }) {
+	if (!url && !thumb_url) return null; // placeholder, no image yet
 	const classes = ['_craftImage'];
 	if (size === 'thumbnail') classes.push('_thumbnail');
 	if (background === 'dark') classes.push('_dark');
-	if (background === 'light') classes.push('_light');
 	if (fit === 'cover') classes.push('_cover');
-	// Render the thumbnail inline (bandwidth-friendly for the 48px tile) but
-	// link to the full-resolution URL on click. When no thumb is supplied the
-	// inline image falls back to the full URL.
+	// show thumb inline, link to full-res; no url → no link
 	const inlineSrc = thumb_url || url;
+	const img = <img src={inlineSrc} alt={caption ?? ''} loading="lazy" />;
 	return (
 		<div className={classes.join(' ')}>
-			<a href={url} target="_blank" rel="noopener noreferrer" title="Click to view full size">
-				<img src={inlineSrc} alt={caption ?? ''} loading="lazy" />
-			</a>
+			{url ? (
+				<a
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer"
+					title="Click to view full size"
+				>
+					{img}
+				</a>
+			) : (
+				img
+			)}
 			{caption && <span className="_craftImageCaption">{caption}</span>}
 		</div>
 	);
@@ -165,16 +175,21 @@ function ListBlock({ items, ordered }: { items: string[]; ordered?: boolean }) {
 }
 
 function RowBlock({
-	children,
+	children = [],
 	styleProperties,
 }: {
-	children: Block[];
+	children?: Block[];
 	styleProperties?: any;
 }) {
+	if (!children.length) return null;
 	return (
 		<div className="_craftRow">
 			{children.map((block, i) => (
-				<CraftBlockRenderer key={i} block={block} styleProperties={styleProperties} />
+				<CraftBlockRenderer
+					key={(block as any).id ?? i}
+					block={block}
+					styleProperties={styleProperties}
+				/>
 			))}
 		</div>
 	);
@@ -217,7 +232,7 @@ function CollapsibleBlock({
 				<div className="_craftCollapsibleBody">
 					{children.map((block, i) => (
 						<CraftBlockRenderer
-							key={i}
+							key={(block as any).id ?? i}
 							block={block}
 							styleProperties={styleProperties}
 						/>
@@ -269,7 +284,7 @@ export function CraftRenderer({
 			<SubHelperComponent definition={definition} subComponentName="craftContent" />
 			{blocks.map((block, i) => (
 				<CraftBlockRenderer
-					key={i}
+					key={(block as any).id ?? i}
 					block={block}
 					styleProperties={styleProperties}
 				/>


### PR DESCRIPTION
## Why
The AdPilot backend (nocode-ai #62, live on dev) streams craft-panel updates as `append=True` blocks carrying stable `id`s (e.g. `panel_image`, `assets_label`), expecting same-id blocks to **replace in place**. Dev's UI predates that contract and appends everything — visible as a **double website screenshot** and stacked duplicate asset labels ("Logo / Logo · 1 product image / Logo · 2 product images") in the craft panel.

## What
- `0a5879d1` — id-based block merge in the craft event handler (same-id block replaces, new blocks append) + tool_update routing 3-priority + telemetry counter
- `57139e27` — agent tool rows + craft receipt blocks redesign (PromptStyle, AgentGroup, CraftPanel, CraftRenderer)

## Verify
Fresh scrape in AdPilot → craft panel shows ONE screenshot (early viewport shot swapped in place by the final full-page shot) and a single coalescing asset row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Updates (2026-06-11)

- **Craft panel auto-scroll reworked** (`cb4f85e0`): stick-to-bottom intent is read from `wheel`/`touchmove` (human-only events — a programmatic glide can't unstick itself), so id-merged in-place updates (e.g. competitors filling in) now follow correctly. Big jumps glide smooth, small growth snaps instantly, craft-switch snaps fresh.
- **Design note**: finished tool rows intentionally show the outcome (summary) only — per-update progress lines are ephemeral by design and not kept after completion.
