### PR TITLE
Enables TableDynamicColumn to accept custom child components per fiel…

### DIFF
--- a/ui-app/client/src/components/TableComponents/TableColumn/TableColumn.tsx
+++ b/ui-app/client/src/components/TableComponents/TableColumn/TableColumn.tsx
@@ -4,7 +4,7 @@ import {
 	PageStoreExtractor,
 	UrlDetailsExtractor,
 } from '../../../context/StoreContext';
-import { ComponentDefinition, ComponentProps } from '../../../types/common';
+import { ComponentDefinition, ComponentProps, LocationHistory } from '../../../types/common';
 import { processComponentStylePseudoClasses } from '../../../util/styleProcessor';
 import Children from '../../Children';
 import { HelperComponent } from '../../HelperComponents/HelperComponent';
@@ -31,6 +31,13 @@ export default function TableColumnComponent(props: Readonly<ComponentProps>) {
 			pageExtractor,
 			urlExtractor,
 		);
+
+	// Read directly from raw definition properties — not via useDefinition
+	// since dynamicChildField is a synthetic internal property not declared
+	// in propertiesDefinition.
+	const dynamicChildField = definition.properties?.dynamicChildField?.value as
+		| string
+		| undefined;
 
 	const [hover, setHover] = useState(false);
 	const [treeHover, setTreeHover] = useState(false);
@@ -66,6 +73,34 @@ export default function TableColumnComponent(props: Readonly<ComponentProps>) {
 		context.table.showSpinner &&
 		context.table.spinnerType.startsWith('_emptyRow');
 
+	// If this TableColumn was synthesised by TableDynamicColumn with user
+	// children, push one extra location history level so that `Parent`
+	// inside the children resolves to the field value (e.g. row.fresh)
+	// rather than the full row object.
+	const childLocationHistory: LocationHistory[] =
+		dynamicChildField && locationHistory.length > 0
+			? [
+					...locationHistory,
+					{
+						location: {
+							type: 'EXPRESSION' as const,
+							expression:
+								(typeof locationHistory[locationHistory.length - 1].location === 'string'
+									? locationHistory[locationHistory.length - 1].location
+									: ((locationHistory[locationHistory.length - 1].location as any)
+											?.expression ??
+										(locationHistory[locationHistory.length - 1].location as any)
+											?.value ??
+										'')) +
+								`.${dynamicChildField}`,
+						},
+						index: locationHistory[locationHistory.length - 1].index,
+						pageName: context.pageName,
+						componentKey: definition.key,
+					},
+				]
+			: locationHistory;
+
 	if (isLoading) {
 		dataPart = <div className={`_animateData ${context.table.spinnerType}`}>&nbsp;</div>;
 	} else {
@@ -74,7 +109,7 @@ export default function TableColumnComponent(props: Readonly<ComponentProps>) {
 				pageDefinition={pageDefinition}
 				renderableChildren={firstchild}
 				context={context}
-				locationHistory={locationHistory}
+				locationHistory={childLocationHistory}
 			/>
 		);
 	}

--- a/ui-app/client/src/components/TableComponents/TableColumn/TableColumn.tsx
+++ b/ui-app/client/src/components/TableComponents/TableColumn/TableColumn.tsx
@@ -9,6 +9,7 @@ import { processComponentStylePseudoClasses } from '../../../util/styleProcessor
 import Children from '../../Children';
 import { HelperComponent } from '../../HelperComponents/HelperComponent';
 import { SubHelperComponent } from '../../HelperComponents/SubHelperComponent';
+import { updateLocationForChild } from '../../util/updateLoactionForChild';
 import useDefinition from '../../util/useDefinition';
 import { propertiesDefinition, stylePropertiesDefinition } from './tableCloumnProperties';
 
@@ -32,12 +33,10 @@ export default function TableColumnComponent(props: Readonly<ComponentProps>) {
 			urlExtractor,
 		);
 
-	// Read directly from raw definition properties — not via useDefinition
+	// Read directly from raw definition properties, not via useDefinition,
 	// since dynamicChildField is a synthetic internal property not declared
 	// in propertiesDefinition.
-	const dynamicChildField = definition.properties?.dynamicChildField?.value as
-		| string
-		| undefined;
+	const dynamicChildField = definition.properties?.dynamicChildField?.value as string | undefined;
 
 	const [hover, setHover] = useState(false);
 	const [treeHover, setTreeHover] = useState(false);
@@ -76,28 +75,22 @@ export default function TableColumnComponent(props: Readonly<ComponentProps>) {
 	// If this TableColumn was synthesised by TableDynamicColumn with user
 	// children, push one extra location history level so that `Parent`
 	// inside the children resolves to the field value (e.g. row.fresh)
-	// rather than the full row object.
+	// rather than the full row object. updateLocationForChild appends
+	// `.<field>` for a string index and handles string / VALUE / EXPRESSION
+	// location shapes with the correct type semantics.
+	const lastHistoryEntry = locationHistory.at(-1);
 	const childLocationHistory: LocationHistory[] =
-		dynamicChildField && locationHistory.length > 0
+		dynamicChildField && lastHistoryEntry
 			? [
 					...locationHistory,
-					{
-						location: {
-							type: 'EXPRESSION' as const,
-							expression:
-								(typeof locationHistory[locationHistory.length - 1].location === 'string'
-									? locationHistory[locationHistory.length - 1].location
-									: ((locationHistory[locationHistory.length - 1].location as any)
-											?.expression ??
-										(locationHistory[locationHistory.length - 1].location as any)
-											?.value ??
-										'')) +
-								`.${dynamicChildField}`,
-						},
-						index: locationHistory[locationHistory.length - 1].index,
-						pageName: context.pageName,
-						componentKey: definition.key,
-					},
+					updateLocationForChild(
+						definition.key,
+						lastHistoryEntry.location,
+						dynamicChildField,
+						locationHistory.slice(0, -1),
+						context.pageName,
+						pageExtractor,
+					),
 				]
 			: locationHistory;
 
@@ -153,7 +146,10 @@ export default function TableColumnComponent(props: Readonly<ComponentProps>) {
 					onMouseEnter={() => setTreeHover(true)}
 					onMouseLeave={() => setTreeHover(false)}
 				>
-					<SubHelperComponent definition={context.table?.columnsDefinition ?? definition} subComponentName="treeCell" />
+					<SubHelperComponent
+						definition={context.table?.columnsDefinition ?? definition}
+						subComponentName="treeCell"
+					/>
 					{treePrefix}
 					<span className="_treeCellContent">{dataPart}</span>
 				</div>
@@ -175,7 +171,17 @@ function renderTreeCellContent(params: {
 	hoverStyles: any;
 	definition: ComponentDefinition;
 }): React.ReactNode {
-	const { row, showConnectors, indentSize, expandIcon, collapseIcon, toggleExpand, normalStyles, hoverStyles, definition } = params;
+	const {
+		row,
+		showConnectors,
+		indentSize,
+		expandIcon,
+		collapseIcon,
+		toggleExpand,
+		normalStyles,
+		hoverStyles,
+		definition,
+	} = params;
 	const indents: React.ReactNode[] = [];
 	const lineStyle = normalStyles.treeLines ?? {};
 	const sizeStyle = { width: indentSize, minWidth: indentSize };
@@ -215,17 +221,25 @@ function renderTreeCellContent(params: {
 		if (row.depth === 0) {
 			// Root level sibling lines
 			if (row.isFirstChild && !row.isLastChild) {
-				wrapLines.push(<div key="rootLine" className="_treeLine _verticalBottom" style={lineStyle} />);
+				wrapLines.push(
+					<div key="rootLine" className="_treeLine _verticalBottom" style={lineStyle} />,
+				);
 			} else if (!row.isFirstChild && !row.isLastChild) {
-				wrapLines.push(<div key="rootLine" className="_treeLine _vertical" style={lineStyle} />);
+				wrapLines.push(
+					<div key="rootLine" className="_treeLine _vertical" style={lineStyle} />,
+				);
 			} else if (row.isLastChild && !row.isFirstChild) {
-				wrapLines.push(<div key="rootLine" className="_treeLine _verticalHalf" style={lineStyle} />);
+				wrapLines.push(
+					<div key="rootLine" className="_treeLine _verticalHalf" style={lineStyle} />,
+				);
 			}
 		}
 
 		if (row.isExpanded && row.depth > 0) {
 			// Downward children line for non-root expanded nodes
-			wrapLines.push(<div key="childLine" className="_treeLine _verticalBottom" style={lineStyle} />);
+			wrapLines.push(
+				<div key="childLine" className="_treeLine _verticalBottom" style={lineStyle} />,
+			);
 		}
 
 		indents.push(

--- a/ui-app/client/src/components/TableComponents/TableColumns/TableColumns.tsx
+++ b/ui-app/client/src/components/TableComponents/TableColumns/TableColumns.tsx
@@ -1052,37 +1052,89 @@ function generateDynamicColumns(
 		if (sortColumns)
 			sortColumnsArray = Object.values(sortColumns).map(col => col.property.value);
 
+		// Collect user-defined children of TableDynamicColumn (if any).
+		const dynamicColumnChildKeys: string[] = dynamicColumn.children
+			? Object.entries(dynamicColumn.children)
+					.filter(([, v]) => v)
+					.map(([k]) => k)
+			: [];
+
+		// Recursively collect all component keys in a subtree.
+		const collectSubtree = (rootKey: string): string[] => {
+			const result: string[] = [rootKey];
+			const comp = cp.componentDefinition[rootKey];
+			if (!comp?.children) return result;
+			for (const [ck, cv] of Object.entries(comp.children))
+				if (cv) result.push(...collectSubtree(ck));
+			return result;
+		};
+
 		for (let i = 0; i < columns.length; i++) {
 			const eachField = columns[i];
-
-			const childRendererKey = `${key}${eachField}_renderer`;
-			const eachRenderer: ComponentDefinition = {
-				key: childRendererKey,
-				type: 'Text',
-				name: eachField + 'Text',
-				properties: {
-					text: {
-						location: { type: 'EXPRESSION', expression: `Parent.${eachField}` },
-					},
-				},
-			};
 
 			const styleProperties = dynamicColumn?.styleProperties
 				? duplicate(dynamicColumn.styleProperties)
 				: undefined;
+
+			let columnChildren: { [k: string]: boolean };
+			let dynamicChildField: string | undefined;
+
+			if (dynamicColumnChildKeys.length > 0) {
+				// Clone the user's children subtree so each field column
+				// gets independent component keys.
+				columnChildren = {};
+				const keyMap: { [orig: string]: string } = {};
+				for (const origKey of dynamicColumnChildKeys) {
+					for (const sk of collectSubtree(origKey))
+					keyMap[sk] = `${key}${eachField}_${sk}`;
+				}
+				for (const [origKey, newKey] of Object.entries(keyMap)) {
+					const origComp = cp.componentDefinition[origKey];
+					if (!origComp) continue;
+					const cloned: ComponentDefinition = duplicate(origComp);
+					cloned.key = newKey;
+					if (cloned.children) {
+						const remapped: { [k: string]: boolean } = {};
+						for (const [ck, cv] of Object.entries(cloned.children))
+							remapped[keyMap[ck] ?? ck] = cv as boolean;
+						cloned.children = remapped;
+					}
+					cp.componentDefinition[newKey] = cloned;
+				}
+				for (const origKey of dynamicColumnChildKeys)
+					if (keyMap[origKey]) columnChildren[keyMap[origKey]] = true;
+				// Tell TableColumn to push Parent.<eachField> onto location
+				// history so children can use just `Parent` to access the
+				// field value (e.g. Parent.percentage, Parent.count).
+				dynamicChildField = eachField;
+			} else {
+				// Default: auto-generate a Text renderer for Parent.<field>.
+				const childRendererKey = `${key}${eachField}_renderer`;
+				cp.componentDefinition[childRendererKey] = {
+					key: childRendererKey,
+					type: 'Text',
+					name: eachField + 'Text',
+					properties: {
+						text: {
+							location: { type: 'EXPRESSION', expression: `Parent.${eachField}` },
+						},
+					},
+				};
+				columnChildren = { [childRendererKey]: true };
+			}
+
+			const eachChildProperties: any = { label: { value: columnNamesIndex[eachField] } };
+			if (dynamicChildField)
+				eachChildProperties.dynamicChildField = { value: dynamicChildField };
 
 			const eachChild: ComponentDefinition = {
 				key: `${key}${eachField}`,
 				type: 'TableColumn',
 				name: eachField,
 				displayOrder: i,
-				properties: {
-					label: {
-						value: columnNamesIndex[eachField],
-					},
-				},
+				properties: eachChildProperties,
 				styleProperties,
-				children: { [eachRenderer.key]: true },
+				children: columnChildren,
 			};
 
 			if (
@@ -1095,7 +1147,6 @@ function generateDynamicColumns(
 				};
 			}
 
-			cp.componentDefinition[eachRenderer.key] = eachRenderer;
 			cp.componentDefinition[eachChild.key] = eachChild;
 			children[eachChild.key] = true;
 		}

--- a/ui-app/client/src/components/TableComponents/TableColumns/TableColumns.tsx
+++ b/ui-app/client/src/components/TableComponents/TableColumns/TableColumns.tsx
@@ -654,13 +654,10 @@ function resolvePropertiesOfDynamicColumns(
 		}
 
 		if (groupedColumns.length) {
-			const propDefMap = tableDynamicGroupedColumnPropertiesDefinition.reduce(
-				(a: any, c) => {
-					a[c.name] = c;
-					return a;
-				},
-				{},
-			);
+			const propDefMap = tableDynamicGroupedColumnPropertiesDefinition.reduce((a: any, c) => {
+				a[c.name] = c;
+				return a;
+			}, {});
 
 			for (let groupedColumn of groupedColumns) {
 				const paths = getPathsFromComponentDefinition(
@@ -892,7 +889,8 @@ function generateTableColumnDefinitions(
 
 	let cp = pageDefinition;
 	if (dynamicColumns.length > 0 || groupedColumns.length > 0) {
-		if (dynamicColumns.length > 0) generateDynamicColumns(dynamicColumns, context, cp, children);
+		if (dynamicColumns.length > 0)
+			generateDynamicColumns(dynamicColumns, context, cp, children);
 		if (groupedColumns.length > 0)
 			generateGroupedDynamicColumns(
 				groupedColumns,
@@ -1059,13 +1057,16 @@ function generateDynamicColumns(
 					.map(([k]) => k)
 			: [];
 
-		// Recursively collect all component keys in a subtree.
-		const collectSubtree = (rootKey: string): string[] => {
+		// Recursively collect all component keys in a subtree. The visited
+		// set guards against cycles in a corrupted definition.
+		const collectSubtree = (rootKey: string, visited = new Set<string>()): string[] => {
+			if (visited.has(rootKey)) return [];
+			visited.add(rootKey);
 			const result: string[] = [rootKey];
 			const comp = cp.componentDefinition[rootKey];
 			if (!comp?.children) return result;
 			for (const [ck, cv] of Object.entries(comp.children))
-				if (cv) result.push(...collectSubtree(ck));
+				if (cv) result.push(...collectSubtree(ck, visited));
 			return result;
 		};
 
@@ -1086,7 +1087,7 @@ function generateDynamicColumns(
 				const keyMap: { [orig: string]: string } = {};
 				for (const origKey of dynamicColumnChildKeys) {
 					for (const sk of collectSubtree(origKey))
-					keyMap[sk] = `${key}${eachField}_${sk}`;
+						keyMap[sk] = `${key}${eachField}_${sk}`;
 				}
 				for (const [origKey, newKey] of Object.entries(keyMap)) {
 					const origComp = cp.componentDefinition[origKey];
@@ -1123,7 +1124,9 @@ function generateDynamicColumns(
 				columnChildren = { [childRendererKey]: true };
 			}
 
-			const eachChildProperties: any = { label: { value: columnNamesIndex[eachField] } };
+			const eachChildProperties: NonNullable<ComponentDefinition['properties']> = {
+				label: { value: columnNamesIndex[eachField] },
+			};
 			if (dynamicChildField)
 				eachChildProperties.dynamicChildField = { value: dynamicChildField };
 
@@ -1189,9 +1192,7 @@ function generateGroupedDynamicColumns(
 
 		// Page-state path holding the per-stage expanded flags. Default
 		// `Page.expandedStages` — keyed by stageId → truthy when expanded.
-		const expandedGroupsPath = String(
-			propValue('expandedGroupsPath', 'Page.expandedStages'),
-		);
+		const expandedGroupsPath = String(propValue('expandedGroupsPath', 'Page.expandedStages'));
 		const expandedMap =
 			getDataFromPath(expandedGroupsPath, locationHistory, pageExtractor) ?? {};
 
@@ -1327,8 +1328,7 @@ function generateGroupedDynamicColumns(
 			const toggleEfKey = hasLeaves ? synthToggleEventKey(gid) : undefined;
 
 			const isExpanded =
-				forceExpandAll ||
-				!!expandedMap?.[`s_${String(gid).replace(/[^a-zA-Z0-9]/g, '')}`];
+				forceExpandAll || !!expandedMap?.[`s_${String(gid).replace(/[^a-zA-Z0-9]/g, '')}`];
 
 			// Parent group: rollup column. Wire headerOnClick to the toggle and
 			// pass isExpanded so the chevron reflects current state.

--- a/ui-app/client/src/components/TableComponents/index.tsx
+++ b/ui-app/client/src/components/TableComponents/index.tsx
@@ -246,6 +246,7 @@ export const TableDynamicColumn: Component = {
 	properties: tableDynamicColumnPropertiesDefinition,
 	styleComponent: () => <></>,
 	styleDefaults: tableColumnStyleDefaults,
+	allowedChildrenType: new Map<string, number>([['', -1]]),
 	parentType: 'TableColumns',
 	stylePseudoStates: ['hover'],
 	stylePropertiesForTheme: [],

--- a/ui-app/client/src/components/TableComponents/index.tsx
+++ b/ui-app/client/src/components/TableComponents/index.tsx
@@ -246,7 +246,7 @@ export const TableDynamicColumn: Component = {
 	properties: tableDynamicColumnPropertiesDefinition,
 	styleComponent: () => <></>,
 	styleDefaults: tableColumnStyleDefaults,
-	allowedChildrenType: new Map<string, number>([['', -1]]),
+	allowedChildrenType: new Map<string, number>([['', 1]]),
 	parentType: 'TableColumns',
 	stylePseudoStates: ['hover'],
 	stylePropertiesForTheme: [],


### PR DESCRIPTION
…d column.  Each synthesised TableColumn now independently clones the child subtree and  pushes Parent.<field> onto location history so children resolve correctly.

Added support for custom user-defined children inside TableDynamicColumn. Previously it only auto-generated a plain Text renderer per field. Now if the user adds children, the full component subtree is cloned independently per field column with unique keys to avoid conflicts, and each synthesised TableColumn pushes Parent. onto location history so children can correctly access their field value using Parent. If no children are added, the existing auto Text renderer behaviour remains unchanged.