### PR TITLE
Feature: Added axis step-size configurations and automatic integer scaling for charts

### DIFF
--- a/ui-app/client/src/components/Chart/chartProperties.ts
+++ b/ui-app/client/src/components/Chart/chartProperties.ts
@@ -188,6 +188,12 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 		group: ComponentPropertyGroup.DATA,
 	},
 	{
+		name: 'xAxisStepSize',
+		schema: SCHEMA_NUM_COMP_PROP,
+		displayName: 'X Axis Step Size',
+		group: ComponentPropertyGroup.DATA,
+	},
+	{
 		name: 'xAxisReverse',
 		schema: SCHEMA_BOOL_COMP_PROP,
 		displayName: 'X Axis Reverse',
@@ -317,6 +323,12 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 		name: 'yAxisSuggestedMax',
 		schema: SCHEMA_NUM_COMP_PROP,
 		displayName: 'Y Axis Suggested Max',
+		group: ComponentPropertyGroup.DATA,
+	},
+	{
+		name: 'yAxisStepSize',
+		schema: SCHEMA_NUM_COMP_PROP,
+		displayName: 'Y Axis Step Size',
 		group: ComponentPropertyGroup.DATA,
 	},
 	{

--- a/ui-app/client/src/components/Chart/chartjs/__tests__/configBuilder.test.ts
+++ b/ui-app/client/src/components/Chart/chartjs/__tests__/configBuilder.test.ts
@@ -355,6 +355,39 @@ describe('buildChartJsOptions', () => {
 			expect(options.scales.y.suggestedMin).toBe(10);
 			expect(options.scales.y.suggestedMax).toBe(90);
 		});
+
+		it('should apply stepSize for ticks if provided', () => {
+			const properties = createMockProperties({
+				xAxisStepSize: 5,
+				yAxisStepSize: 10,
+			});
+			const chartData = createMockChartData({
+				xAxisType: 'value',
+				yAxisType: 'value',
+			});
+
+			const options = buildChartJsOptions(properties, chartData, 'line') as any;
+
+			expect(options.scales.x.ticks.stepSize).toBe(5);
+			expect(options.scales.y.ticks.stepSize).toBe(10);
+		});
+
+		it('should automatically set stepSize to 1 if all values are integers and range is small', () => {
+			const properties = createMockProperties();
+			const chartData = createMockChartData({
+				xAxisType: 'value',
+				yAxisType: 'value',
+				xUniqueData: [0, 1, 2, 3, 4],
+				yUniqueData: [0, 1, 2, 3, 4],
+			});
+
+			const options = buildChartJsOptions(properties, chartData, 'line') as any;
+
+			expect(options.scales.x.ticks.stepSize).toBe(1);
+			expect(options.scales.y.ticks.stepSize).toBe(1);
+			expect(options.scales.x.ticks.callback(0.5)).toBeUndefined();
+			expect(options.scales.x.ticks.callback(2)).toBe(2);
+		});
 	});
 
 	describe('axis position', () => {

--- a/ui-app/client/src/components/Chart/chartjs/configBuilder.ts
+++ b/ui-app/client/src/components/Chart/chartjs/configBuilder.ts
@@ -401,6 +401,30 @@ function buildScalesOptions(
 		yAxisType = 'linear';
 	}
 
+	const xAxisTicks: any = {
+		display: !properties.xAxisHideLabels,
+	};
+	if (properties.xAxisStepSize !== undefined) {
+		xAxisTicks.stepSize = properties.xAxisStepSize;
+	} else if (xAxisType === 'linear' && !hasOrdinalYValues && chartData.xUniqueData.length > 0) {
+		const xValues = chartData.xUniqueData.map(val => Number(val)).filter(val => !isNaN(val));
+		const allXValuesAreIntegers = xValues.length > 0 && xValues.every(val => Number.isInteger(val));
+		if (allXValuesAreIntegers) {
+			const maxVal = Math.max(...xValues);
+			const minVal = Math.min(...xValues);
+			const range = maxVal - minVal;
+			if (range <= 10) {
+				xAxisTicks.stepSize = 1;
+			}
+			xAxisTicks.callback = function(value: number) {
+				if (value % 1 === 0) {
+					return value;
+				}
+				return undefined;
+			};
+		}
+	}
+
 	// Build custom ticks for ordinal Y values
 	const xAxisOrdinalTicks = isHorizontalBar && hasOrdinalYValues ? {
 		display: !properties.xAxisHideLabels,
@@ -411,7 +435,31 @@ function buildScalesOptions(
 			const index = value - 1;
 			return chartData.yUniqueData[index] || '';
 		},
-	} : { display: !properties.xAxisHideLabels };
+	} : xAxisTicks;
+
+	const yAxisTicks: any = {
+		display: !properties.yAxisHideLabels,
+	};
+	if (properties.yAxisStepSize !== undefined) {
+		yAxisTicks.stepSize = properties.yAxisStepSize;
+	} else if (yAxisType === 'linear' && !hasOrdinalYValues && chartData.yUniqueData.length > 0) {
+		const yValues = chartData.yUniqueData.map(val => Number(val)).filter(val => !isNaN(val));
+		const allYValuesAreIntegers = yValues.length > 0 && yValues.every(val => Number.isInteger(val));
+		if (allYValuesAreIntegers) {
+			const maxVal = Math.max(...yValues);
+			const minVal = Math.min(...yValues);
+			const range = maxVal - minVal;
+			if (range <= 10) {
+				yAxisTicks.stepSize = 1;
+			}
+			yAxisTicks.callback = function(value: number) {
+				if (value % 1 === 0) {
+					return value;
+				}
+				return undefined;
+			};
+		}
+	}
 
 	const yAxisOrdinalTicks = !isHorizontalBar && chartData.hasBar && hasOrdinalYValues ? {
 		display: !properties.yAxisHideLabels,
@@ -422,7 +470,7 @@ function buildScalesOptions(
 			const index = value - 1;
 			return chartData.yUniqueData[index] || '';
 		},
-	} : { display: !properties.yAxisHideLabels };
+	} : yAxisTicks;
 
 	const scales: Record<string, any> = {
 		x: {

--- a/ui-app/client/src/components/Chart/types/common.ts
+++ b/ui-app/client/src/components/Chart/types/common.ts
@@ -120,6 +120,7 @@ export interface ChartProperties {
 	xAxisSuggestedMin?: number; // Done.
 	xAxisMax?: number; // Done.
 	xAxisSuggestedMax?: number; // Done.
+	xAxisStepSize?: number;
 	xAxisReverse?: boolean;
 	xAxisHideTicks?: boolean;
 	xAxisHideLabels?: boolean;
@@ -137,6 +138,7 @@ export interface ChartProperties {
 	yAxisSuggestedMin?: number; // Done.
 	yAxisMax?: number; // Done.
 	yAxisSuggestedMax?: number; // Done.
+	yAxisStepSize?: number;
 	yAxisReverse?: boolean;
 	yAxisHideTicks?: boolean;
 	yAxisHideLabels?: boolean;


### PR DESCRIPTION
Resolved the issue where value axes (like the Y-axis for Deals) automatically show decimal divisions (e.g., 0.5, 1.5) for whole-number data.

Key Changes:
1. Added `xAxisStepSize` and `yAxisStepSize` to the chart property definition schemas to allow manual configuration.
2. Implemented auto-detection logic in the scale options builder: when the axis type is numeric (linear) and the dataset contains only whole numbers, it sets stepSize to 1 for small ranges (<= 10) and filters out any decimal tick labels.
3. Added unit tests verifying both manual overrides and the auto-integer scaling behaviors.